### PR TITLE
Fixes chat re-opening on Sending Message when bound to Enter

### DIFF
--- a/Scripts/Game/Chat.gd
+++ b/Scripts/Game/Chat.gd
@@ -35,19 +35,22 @@ func _ready():
 
 
 func _process(delta) -> void:
-	if Input.is_action_just_pressed("ui_accept"): 
-		send_chat_message()
-	
-	if Input.is_action_just_pressed("ui_cancel"): 
-		close_chat()
-	
-	if Input.is_action_just_pressed("open_chat") && _focused == false: 
-		open_chat()
-	
 	if chatInput.text.length() > 512:
 		sendChatMsg.disabled = true
 	else:
 		sendChatMsg.disabled = false
+	
+	if Input.is_action_just_pressed("ui_accept") && _focused: 
+		send_chat_message()
+		return
+	
+	if Input.is_action_just_pressed("ui_cancel"): 
+		close_chat()
+		return
+	
+	if Input.is_action_just_pressed("open_chat") && not _focused: 
+		open_chat()
+		return
 
 
 func open_chat():


### PR DESCRIPTION
# What does this do?
Currently binding chat to Enter causes a problem: When you send a message with Enter it instantly re-opens chat which forces you to close it by double tapping Escape
This PR adds few extra checks to prevent this from happening

# How does it do so?
Using `return` in `if` blocks to not trigger chat opening and closing on the same update, checking for `_focused` as extra step

# Why should this be merged?
I am fairly sure it is a bug, and as I remember wise person once said:
>   "Bug Bad" 
> -Sensei and Bug Exterminator, Danchi.

# Testing
Run the game, entered training mode, sent a bunch of messages using Enter.

# Changelog:
Fix: Binding Chat to Enter will now allow you to close chat